### PR TITLE
Fix Github URLs after branch reorganization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,10 @@ sphobjinv: Manipulate and inspect Sphinx objects.inv files
 
 **Current Development Version:**
 
-.. image:: https://travis-ci.org/bskinn/sphobjinv.svg?branch=dev
+.. image:: https://travis-ci.org/bskinn/sphobjinv.svg?branch=master
     :target: https://travis-ci.org/bskinn/sphobjinv
 
-.. image:: https://codecov.io/gh/bskinn/sphobjinv/branch/dev/graph/badge.svg
+.. image:: https://codecov.io/gh/bskinn/sphobjinv/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/bskinn/sphobjinv
 
 **Most Recent Stable Release:**
@@ -22,7 +22,7 @@ sphobjinv: Manipulate and inspect Sphinx objects.inv files
     :target: http://sphobjinv.readthedocs.io/en/latest/
 
 .. image:: https://img.shields.io/github/license/mashape/apistatus.svg
-    :target: https://github.com/bskinn/sphobjinv/blob/master/LICENSE.txt
+    :target: https://github.com/bskinn/sphobjinv/blob/stable/LICENSE.txt
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black

--- a/conftest.py
+++ b/conftest.py
@@ -97,7 +97,7 @@ def misc_info(res_path):
 
         # For the URL mode of Inventory instantiation
         remote_url = (
-            "https://github.com/bskinn/sphobjinv/raw/dev/"
+            "https://github.com/bskinn/sphobjinv/raw/master/"
             "tests/resource/objects_{0}.inv"
         )
 

--- a/doc/source/api_usage.rst
+++ b/doc/source/api_usage.rst
@@ -57,7 +57,7 @@ Remote |objects.inv| files can also be retrieved via URL, with the *url* keyword
 
 .. doctest:: api_inspect
 
-    >>> inv4 = soi.Inventory(url='https://github.com/bskinn/sphobjinv/raw/dev/tests/resource/objects_attrs.inv')
+    >>> inv4 = soi.Inventory(url='https://github.com/bskinn/sphobjinv/raw/master/tests/resource/objects_attrs.inv')
     >>> print(inv4)
     <Inventory (url): attrs v17.2, 56 objects>
 

--- a/doc/source/cli/convert.rst
+++ b/doc/source/cli/convert.rst
@@ -64,7 +64,7 @@ indicated URL):
 
 .. doctest:: convert_url
 
-    >>> cli_run('sphobjinv convert plain -u https://github.com/bskinn/sphobjinv/raw/dev/tests/resource/objects_attrs.inv')
+    >>> cli_run('sphobjinv convert plain -u https://github.com/bskinn/sphobjinv/raw/master/tests/resource/objects_attrs.inv')
     <BLANKLINE>
     Remote inventory found.
     <BLANKLINE>

--- a/doc/source/cli/suggest.rst
+++ b/doc/source/cli/suggest.rst
@@ -52,7 +52,7 @@ Remote |objects.inv| files can be retrieved for inspection by passing the
 
 .. doctest:: suggest_main
 
-    >>> cli_run('sphobjinv suggest https://github.com/bskinn/sphobjinv/raw/dev/tests/resource/objects_attrs.inv instance -u -t 48')  # doctest: +NORMALIZE_WHITESPACE
+    >>> cli_run('sphobjinv suggest https://github.com/bskinn/sphobjinv/raw/master/tests/resource/objects_attrs.inv instance -u -t 48')  # doctest: +NORMALIZE_WHITESPACE
     <BLANKLINE>
     Remote inventory found.
     <BLANKLINE>


### PR DESCRIPTION
Also fix README URLs to shields.io and codecov.io, updating them to `master` from `dev`.