### PR TITLE
Adjust attr.s() invocation for cmp argument deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
  - python --version
  - pip list
  - pytest --cov=src --testall --nonloc
+ - tox -e sdist_install
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then tox -e flake8; else echo "No flake8."; fi
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 6 )); then sh -c 'cd doc; make doctest'; else echo "No doctest."; fi
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then codecov; else echo "No codecov."; fi

--- a/src/sphobjinv/inventory.py
+++ b/src/sphobjinv/inventory.py
@@ -44,7 +44,14 @@ from sphobjinv.schema import json_schema
 from sphobjinv.zlib import decompress
 
 
-@attr.s(slots=True, cmp=False)
+# Cope with 'cmp' argument deprecation in attrs 19.2
+try:
+    _attr_wrapper = attr.s(slots=True, eq=False)
+except TypeError:  # pragma: no cover
+    _attr_wrapper = attr.s(slots=True, cmp=False)
+
+
+@_attr_wrapper
 class Inventory(object):
     r"""Entire contents of an |objects.inv| inventory.
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,11 @@ deps=-rrequirements-flake8.txt
 commands=
     flake8 conftest.py tests src
 
+[testenv:sdist_install]
+commands=
+    python -Werror -c "import sphobjinv"
+deps=
+
 [pytest]
 markers =
   local: Tests not requiring Internet access
@@ -76,7 +81,7 @@ markers =
   first: Inherited marker from `pytest-ordering`
   timeout: Inherited marker from `pytest-timeout`
 
-addopts = --strict --doctest-glob="README.rst" -rsxX -W error::Warning
+addopts = --strict --doctest-glob="README.rst" -rsxX -Werror
 
 norecursedirs = .* env* src *.egg dist build
 


### PR DESCRIPTION
Also add tox env for sphobjinv import-time warnings -- these are not captured by pytest's machinery!