### PR TITLE
Miscellaneous docs tweaks; update regex patterns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ script:
  - tox -e sdist_install
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then tox -e flake8; else echo "No flake8."; fi
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then sh -c 'cd doc; make doctest'; else echo "No doctest."; fi
+ - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then sh -c 'cd doc; make linkcheck'; else echo "No linkcheck."; fi
  - if (( $PYTHON_MAJOR == 3 && $PYTHON_MINOR == 7 )); then codecov; else echo "No codecov."; fi
 

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ for more details.
 Full documentation is hosted at
 `Read The Docs <http://sphobjinv.readthedocs.io/en/latest/>`__.
 
-Available on `PyPI <https://pypi.python.org/pypi/sphobjinv>`__
+Available on `PyPI <https://pypi.org/project/sphobjinv>`__
 (``pip install sphobjinv``).
 
 Source on `GitHub <https://github.com/bskinn/sphobjinv>`__.  Bug reports

--- a/doc/source/cli/convert.rst
+++ b/doc/source/cli/convert.rst
@@ -108,13 +108,9 @@ If download of JSON files by URL is desirable, please
 
 **Usage**
 
-.. doctest:: convert_usage
+.. command-output:: sphobjinv convert --help
+    :ellipsis: 4
 
-    >>> cli_run('sphobjinv convert --help', head=4)
-    usage: sphobjinv convert [-h] [-e | -c] [-o] [-q] [-u]
-                             {zlib,plain,json} infile [outfile]
-    <BLANKLINE>
-    Convert intersphinx inventory to zlib-compressed, plaintext, or JSON formats.
 
 **Positional Arguments**
 

--- a/doc/source/cli/index.rst
+++ b/doc/source/cli/index.rst
@@ -15,8 +15,8 @@ Some notes on these CLI docs:
 
  * CLI examples are executed in a sandboxed directory pre-loaded with
    |cour|\ objects_attrs.inv\ |/cour| (from, e.g.,
-   `here <https://github.com/bskinn/sphobjinv/blob/master/sphobjinv/
-   test/resource/objects_attrs.inv>`__).
+   `here <https://github.com/bskinn/sphobjinv/blob/master/
+   tests/resource/objects_attrs.inv>`__).
 
  * :class:`~pathlib.Path` (from :mod:`pathlib`)
    is imported into the namespace before all tests.

--- a/doc/source/cli/index.rst
+++ b/doc/source/cli/index.rst
@@ -38,46 +38,14 @@ The options for the parent |soi| command are:
 
     Show help message and exit
 
-.. doctest:: soi_base
-
-    >>> cli_run('sphobjinv --help')
-    usage: sphobjinv [-h] [-v] {convert,suggest} ...
-    <BLANKLINE>
-    Format conversion for and introspection of intersphinx 'objects.inv' files.
-    <BLANKLINE>
-    optional arguments:
-      -h, --help         show this help message and exit
-      -v, --version      Print package version & other info
-    <BLANKLINE>
-    Subcommands:
-      {convert,suggest}  Execution mode. Type 'sphobjinv [mode] -h' for more
-                         information on available options. Mode names can be
-                         abbreviated to their first two letters.
-        convert (co)     Convert intersphinx inventory to zlib-compressed,
-                         plaintext, or JSON formats.
-        suggest (su)     Fuzzy-search intersphinx inventory for desired object(s).
-    <BLANKLINE>
+.. program-output:: sphobjinv --help
 
 
 .. option:: -v, --version
 
     Print package version & other info
 
-.. doctest:: soi_base
-
-    >>> cli_run('sphobjinv --version')
-    <BLANKLINE>
-    sphobjinv v2.0.1
-    <BLANKLINE>
-    Copyright (c) Brian Skinn 2016-2020
-    License: The MIT License
-    <BLANKLINE>
-    Bug reports & feature requests: https://github.com/bskinn/sphobjinv
-    Documentation: http://sphobjinv.readthedocs.io
-    <BLANKLINE>
-    <BLANKLINE>
-
-
+.. program-output:: sphobjinv --version
 
 
 .. toctree::

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.programoutput",
     "sphinx_issues",
 ]
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -244,7 +244,7 @@ os.chdir(str(_start_dir))
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "sphinx": ("http://www.sphinx-doc.org/en/master", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -64,7 +64,9 @@ pygments_style = "sphinx"
 # Ignore package prefix when sorting modules
 modindex_common_prefix = ["sphobjinv."]
 
-# Common epilogue
+
+# -- Common epilogue definition  ------------------------------------------------
+
 rst_epilog = r"""
 .. |extlink| image:: /_static/extlink.svg
 
@@ -136,7 +138,7 @@ rst_epilog = r"""
 
 .. |isphxmap| replace:: ``intersphinx_mapping``
 
-.. _isphxmap: http://www.sphinx-doc.org/en/stable/ext/intersphinx.html#confval-intersphinx_mapping
+.. _isphxmap: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
 
 .. |soi| raw:: html
 
@@ -148,7 +150,10 @@ rst_epilog = r"""
 
 """
 
-# Universal doctest setup code
+
+# -- doctest setup code  --------------------------------------------
+
+
 doctest_global_setup = """\
 import os
 from pathlib import Path
@@ -246,6 +251,11 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
+
+
+# -- Options for linkcheck  --------------------------------------------------
+
+linkcheck_anchors_ignore = [r"^L\d+$", r"^L\d+-L\d+$"]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/doc/source/customfile.rst
+++ b/doc/source/customfile.rst
@@ -71,10 +71,10 @@ can be found at the GitHub repo
 
             The `role` values here must be the **full** role names ("`block directives`"),
             described as the "directives" in the `Sphinx documentation for
-            domains <http://www.sphinx-doc.org/en/1.7/domains.html#the-python-domain>`__,
+            domains <https://www.sphinx-doc.org/en/1.7/domains.html#the-python-domain>`__,
             and not the abbreviated forms ("`inline directives`")
             `used when constructing cross-references
-            <http://www.sphinx-doc.org/en/1.7/domains.html#cross-referencing-python-objects>`__.
+            <https://www.sphinx-doc.org/en/1.7/domains.html#cross-referencing-python-objects>`__.
 
             Thus, for example, a :class:`~sphobjinv.data.DataObjStr` corresponding
             to a method on a class should be constructed with
@@ -146,10 +146,10 @@ can be found at the GitHub repo
                 'python': ('https://docs.python.org/3.5', None),
 
                 # Django puts its objects.inv file in a non-standard location
-                'django': ('http://docs.djangoproject.com/en/dev/', 'https://docs.djangoproject.com/en/dev/_objects/'),
+                'django': ('https://docs.djangoproject.com/en/dev/', 'https://docs.djangoproject.com/en/dev/_objects/'),
 
                 # Drawing the Sphinx objects.inv from a local copy, but referring to the 1.7 web docs
-                'sphinx': ('http://www.sphinx-doc.org/en/1.7/', '/path/to/local/objects.inv',
+                'sphinx': ('https://www.sphinx-doc.org/en/1.7/', '/path/to/local/objects.inv',
             }
 
     .. MAKE SURE TO UPDATE THESE TWO STEP REFERENCES IF NUMBERING CHANGES!!

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -46,7 +46,7 @@ accelerates the the "suggest" functionality; see
 :doc:`here <levenshtein>` for more information.
 
 The project source repository is on GitHub: `bskinn/sphobjinv
-<https://www.github.com/bskinn/sphobjinv>`__.
+<https://github.com/bskinn/sphobjinv>`__.
 
 
 .. Contents

--- a/doc/source/syntax.rst
+++ b/doc/source/syntax.rst
@@ -154,5 +154,5 @@ as in :obj:`This is join! <str.join>`:
 
 .. |defdom| replace:: default domain
 
-.. _defdom: http://www.sphinx-doc.org/en/stable/domains.html
+.. _defdom: https://www.sphinx-doc.org/en/stable/domains.html
 

--- a/doc/source/syntax.rst
+++ b/doc/source/syntax.rst
@@ -154,5 +154,5 @@ as in :obj:`This is join! <str.join>`:
 
 .. |defdom| replace:: default domain
 
-.. _defdom: https://www.sphinx-doc.org/en/stable/domains.html
+.. _defdom: https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ restview
 sphinx==2.3.1
 sphinx-autobuild
 sphinx-issues
+sphinxcontrib-programoutput
 sphinx-rtd-theme
 stdio-mgr>=1.0.1
 tox

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -2,3 +2,4 @@ attrs>=17.4
 sphinx==2.3.1
 sphinx-issues
 sphinx-rtd-theme
+sphinxcontrib-programoutput

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -12,6 +12,7 @@ pytest-timeout
 sphinx==2.3.1
 sphinx-issues
 sphinx-rtd-theme
+sphinxcontrib-programoutput
 stdio-mgr>=1.0.1
 tox
 -e .

--- a/src/sphobjinv/__init__.py
+++ b/src/sphobjinv/__init__.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/__init__.py
+++ b/src/sphobjinv/__init__.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/cmdline.py
+++ b/src/sphobjinv/cmdline.py
@@ -18,7 +18,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/cmdline.py
+++ b/src/sphobjinv/cmdline.py
@@ -18,10 +18,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms
@@ -53,7 +53,7 @@ VER_TXT = (
     "Bug reports & feature requests:"
     " https://github.com/bskinn/sphobjinv\n"
     "Documentation:"
-    " http://sphobjinv.readthedocs.io\n"
+    " https://sphobjinv.readthedocs.io\n"
 )
 
 # ### Subparser selectors and argparse param for storing subparser name

--- a/src/sphobjinv/data.py
+++ b/src/sphobjinv/data.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/data.py
+++ b/src/sphobjinv/data.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/enum.py
+++ b/src/sphobjinv/enum.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/enum.py
+++ b/src/sphobjinv/enum.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/error.py
+++ b/src/sphobjinv/error.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/error.py
+++ b/src/sphobjinv/error.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/fileops.py
+++ b/src/sphobjinv/fileops.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/fileops.py
+++ b/src/sphobjinv/fileops.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/inventory.py
+++ b/src/sphobjinv/inventory.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/inventory.py
+++ b/src/sphobjinv/inventory.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/inventory.py
+++ b/src/sphobjinv/inventory.py
@@ -513,7 +513,7 @@ class Inventory(object):
         # Define regex for splitting the three components, and
         # use it to convert composite result string to tuple:
         # result --> (rst, score, index)
-        p_idx = re.compile("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
+        p_idx = re.compile(r"^(\d+)\s+(.+?)\s+(\d+)$")
         results = [
             (m.group(2), int(m.group(3)), int(m.group(1)))
             for m in map(p_idx.match, results)

--- a/src/sphobjinv/re.py
+++ b/src/sphobjinv/re.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/re.py
+++ b/src/sphobjinv/re.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/re.py
+++ b/src/sphobjinv/re.py
@@ -37,11 +37,11 @@ pb_comments = re.compile(b"^#.*$", re.M)
 
 #: Compiled |re| |bytes| pattern for project line
 pb_project = re.compile(
-    """
+    r"""
     ^                        # Start of line
     [#][ ]Project:[ ]        # Preamble
     (?P<{}>.*?)              # Lazy rest of line is the project name
-    \\r?$                    # Ignore possible CR at EOL
+    \r?$                     # Ignore possible CR at EOL
     """.format(
         HeaderFields.Project.value
     ).encode(
@@ -52,11 +52,11 @@ pb_project = re.compile(
 
 #: Compiled |re| |bytes| pattern for version line
 pb_version = re.compile(
-    """
+    r"""
     ^                        # Start of line
     [#][ ]Version:[ ]        # Preamble
     (?P<{}>.*?)              # Lazy rest of line is the version
-    \\r?$                    # Ignore possible CR at EOL
+    \r?$                     # Ignore possible CR at EOL
     """.format(
         HeaderFields.Version.value
     ).encode(
@@ -68,21 +68,23 @@ pb_version = re.compile(
 #: Regex pattern string used to compile
 #: :data:`~sphobjinv.re.p_data` and
 #: :data:`~sphobjinv.re.pb_data`
-ptn_data = """\
+ptn_data = (
+    r"""
     ^                        # Start of line
-    (?P<{0}>[^#]\\S+)        # --> Name
-    \\s+                     # Dividing space
-    (?P<{1}>\\w+)            # --> Domain
+    (?P<{0}>[^#]\S+)         # --> Name
+    \s+                      # Dividing space
+    (?P<{1}>\w+)             # --> Domain
     :                        # Dividing colon
-    (?P<{2}>\\w+)            # --> Role
-    \\s+                     # Dividing space
-    (?P<{3}>-?\\d+)          # --> Priority
-    \\s+                     # Dividing space
-    (?P<{4}>\\S+)            # --> URI
-    \\s+                     # Dividing space
+    (?P<{2}>\w+)             # --> Role
+    \s+                      # Dividing space
+    (?P<{3}>-?\d+)           # --> Priority
+    \s+                      # Dividing space
+    (?P<{4}>\S+)             # --> URI
+    \s+                      # Dividing space
     (?P<{5}>.+?)             # --> Display name, lazy b/c possible CR
-    \\r?$                    # Ignore possible CR at EOL
-    """.format(
+    \r?$                     # Ignore possible CR at EOL
+    """
+).format(
     DataFields.Name.value,
     DataFields.Domain.value,
     DataFields.Role.value,

--- a/src/sphobjinv/schema.py
+++ b/src/sphobjinv/schema.py
@@ -14,7 +14,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/schema.py
+++ b/src/sphobjinv/schema.py
@@ -14,10 +14,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms
@@ -47,7 +47,7 @@ subschema_json = {
 #: as generated from or expected by
 #: :class:`~sphobjinv.inventory.Inventory` classes.
 json_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "type": "object",
     "properties": {
         "project": {"type": "string"},

--- a/src/sphobjinv/schema.py
+++ b/src/sphobjinv/schema.py
@@ -56,7 +56,7 @@ json_schema = {
         "metadata": {},
     },
     "patternProperties": {
-        "^\\d+": {
+        r"^\d+": {
             "type": "object",
             "properties": subschema_json,
             "additionalProperties": False,

--- a/src/sphobjinv/version.py
+++ b/src/sphobjinv/version.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/version.py
+++ b/src/sphobjinv/version.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest

--- a/src/sphobjinv/zlib.py
+++ b/src/sphobjinv/zlib.py
@@ -13,10 +13,10 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    http://www.github.com/bskinn/sphobjinv
+    https://www.github.com/bskinn/sphobjinv
 
 **Documentation**
-    http://sphobjinv.readthedocs.io
+    https://sphobjinv.readthedocs.io/en/latest
 
 **License**
     The MIT License; see |license_txt|_ for full license terms

--- a/src/sphobjinv/zlib.py
+++ b/src/sphobjinv/zlib.py
@@ -13,7 +13,7 @@ Sphinx |objects.inv| files.
     \(c) Brian Skinn 2016-2020
 
 **Source Repository**
-    https://www.github.com/bskinn/sphobjinv
+    https://github.com/bskinn/sphobjinv
 
 **Documentation**
     https://sphobjinv.readthedocs.io/en/latest


### PR DESCRIPTION
- Switch certain CLI outputs in docs to `.. program-output::`, to avoid having to manually update things in the docs that have no API significance on every version change
- Add `linkcheck` task to CI and fix links
- Switch all regex patterns to use raw strings, for clarity