### PR TITLE
Add pep517 to req'ts-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ certifi
 coverage
 fuzzywuzzy>=0.3
 jsonschema
+pep517
 pytest>=4.4.0
 pytest-cov
 pytest-ordering


### PR DESCRIPTION
Will enable builds with 'python -m pep517.build' instead of
'python setup.py'.