### PR TITLE
Remove extra newline before suggest tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project strives to adhere to
    now identifies `sphobjinv` and its version (anticipate no API or
    behavior change)
 
+ * An extraneous newline was removed before tables printed in the 
+   'suggest' CLI mode (cosmetic change)
+
+
 ### [2.1b1] - 2020-11-13
 
 #### Fixed

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,7 +7,6 @@ jsonschema
 pytest>=4.4.0
 pytest-cov
 pytest-ordering
-pytest-subtests
 pytest-timeout
 sphinx==2.3.1
 sphinx-issues

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,6 +5,7 @@ coverage
 fuzzywuzzy>=0.3
 jsonschema
 pytest>=4.4.0
+pytest-check
 pytest-cov
 pytest-ordering
 pytest-timeout

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,6 @@ pep517
 pytest>=4.4.0
 pytest-cov
 pytest-ordering
-pytest-subtests
 pytest-timeout
 restview
 rope

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ fuzzywuzzy>=0.3
 jsonschema
 pep517
 pytest>=4.4.0
+pytest-check
 pytest-cov
 pytest-ordering
 pytest-timeout

--- a/src/sphobjinv/cli/core.py
+++ b/src/sphobjinv/cli/core.py
@@ -146,20 +146,17 @@ def do_suggest(inv, params):
             fmt = "{{0: <{0}}}  {{1: ^{1}}}  {{2: ^{2}}}".format(
                 rst_width, score_width, index_width
             )
-            print("")
             print(fmt.format("  Name", "Score", "Index"))
             print(fmt.format("-" * rst_width, "-" * score_width, "-" * index_width))
             print("\n".join(fmt.format(*_) for _ in results))
         else:
             fmt = "{{0: <{0}}}  {{1: ^{1}}}".format(rst_width, index_width)
-            print("")
             print(fmt.format("  Name", "Index"))
             print(fmt.format("-" * rst_width, "-" * index_width))
             print("\n".join(fmt.format(*_) for _ in results))
     else:
         if with_score:
             fmt = "{{0: <{0}}}  {{1: ^{1}}}".format(rst_width, score_width)
-            print("")
             print(fmt.format("  Name", "Score"))
             print(fmt.format("-" * rst_width, "-" * score_width))
             print("\n".join(fmt.format(*_) for _ in results))

--- a/tests/test_api_fail.py
+++ b/tests/test_api_fail.py
@@ -163,22 +163,19 @@ class TestInventory:
         with pytest.raises(RuntimeError):
             soi.Inventory(source="foo", plaintext="bar")
 
-    def test_apifail_inventory_no_object_invs(self, subtests):
+    def test_apifail_inventory_no_object_invs(self, check):
         """Confirm no-objects inventories don't import."""
         inv = soi.Inventory()
 
-        with subtests.test(msg="plain"):
-            with pytest.raises(TypeError):
-                soi.Inventory(inv.data_file())
+        with pytest.raises(TypeError):
+            soi.Inventory(inv.data_file())
 
-        with subtests.test(msg="zlib"):
-            with pytest.raises((TypeError, ValueError)):
-                soi.Inventory(soi.compress(inv.data_file()))
+        with pytest.raises((TypeError, ValueError)):
+            soi.Inventory(soi.compress(inv.data_file()))
 
         d = {"project": "test", "version": "0.0", "count": 0}
-        with subtests.test(msg="json"):
-            with pytest.raises(ValueError):
-                soi.Inventory(d)
+        with pytest.raises(ValueError):
+            soi.Inventory(d)
 
     def test_apifail_compressed_inv_with_win_newlines(self, unix2dos, res_cmp):
         """Confirm that a compressed inventory with Windows newlines does not decompress.

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -242,7 +242,7 @@ class TestDataObj:
         init_expanded,
         dataline_arg,
         misc_info,
-        subtests,
+        check,
     ):
         """Confirm that data line formatting function works.
 
@@ -258,17 +258,15 @@ class TestDataObj:
         # If dataline_arg is False, should match the value of init_expanded.
         # If dataline_arg is True, should match the True (expanded) value.
         # Thus, the only False (contracted) situation is with both values False.
-        with subtests.test(msg="expand"):
-            dl = dobj.data_line(expand=dataline_arg)
-            assert dl == lines_obj[dataline_arg or init_expanded]
+        dl = dobj.data_line(expand=dataline_arg)
+        check.equal(dl, lines_obj[dataline_arg or init_expanded])
 
         # If dataline_arg is False, should match the value of init_expanded.
         # If dataline_arg is True, should match the False (contracted) value.
         # Thus, the only True (expanded) situation is when init_expanded == True
         # and and dataline_arg == False.
-        with subtests.test(msg="contract"):
-            dl = dobj.data_line(contract=dataline_arg)
-            assert dl == lines_obj[init_expanded and not dataline_arg]
+        dl = dobj.data_line(contract=dataline_arg)
+        check.equal(dl, lines_obj[init_expanded and not dataline_arg])
 
     @pytest.mark.parametrize(
         "use_bytes", (True, False), ids=(lambda b: "use_bytes_" + str(b))
@@ -316,21 +314,14 @@ class TestDataObj:
 class TestInventory:
     """Tests of the Inventory class."""
 
-    def test_api_inventory_default_none_instantiation(self, subtests):
+    def test_api_inventory_default_none_instantiation(self, check):
         """Confirm 'manual' instantiation with None."""
         inv = soi.Inventory()
 
-        with subtests.test(msg="project"):
-            assert inv.project is None
-
-        with subtests.test(msg="version"):
-            assert inv.version is None
-
-        with subtests.test(msg="count"):
-            assert inv.count == 0
-
-        with subtests.test(msg="source_type"):
-            assert inv.source_type is soi.SourceTypes.Manual
+        check.is_none(inv.project)
+        check.is_none(inv.version)
+        check.equal(inv.count, 0)
+        check.is_true(inv.source_type is soi.SourceTypes.Manual)
 
     @pytest.mark.parametrize(
         ["source_type", "inv_arg"],
@@ -351,7 +342,7 @@ class TestInventory:
         res_path,
         misc_info,
         attrs_inventory_test,
-        subtests,
+        check,
     ):
         """Check bytes and filename modes for Inventory instantiation."""
         fname = misc_info.FNames.RES
@@ -371,17 +362,17 @@ class TestInventory:
             source = soi.readbytes(source)
 
         # General import, without a specified kwarg
-        with subtests.test(msg="general"):
+        with check.check(msg="general"):
             attrs_inventory_test(soi.Inventory(source), source_type)
 
         # Importing with the respective kwarg for each source type
-        with subtests.test(msg="specific"):
+        with check.check(msg="specific"):
             inv = soi.Inventory(**{inv_arg: source})
             attrs_inventory_test(inv, source_type)
 
         # Special case for plaintext bytes, try decoding it
         if source_type is soi.SourceTypes.BytesPlaintext:
-            with subtests.test(msg="plaintext_bytes"):
+            with check.check(msg="plaintext_bytes"):
                 inv = soi.Inventory(**{inv_arg: source.decode("utf-8")})
                 attrs_inventory_test(inv, source_type)
 
@@ -456,7 +447,7 @@ class TestInventory:
         # 55 b/c the loop continues past missing elements
         assert inv2.count == 55
 
-    def test_api_inventory_namesuggest(self, res_cmp, subtests):
+    def test_api_inventory_namesuggest(self, res_cmp, check):
         """Confirm object name suggestion is nominally working."""
         rst = ":py:function:`attr.evolve`"
         idx = 6
@@ -465,22 +456,18 @@ class TestInventory:
 
         # No test on the exact fuzzywuzzy match score in these since
         # it could change as fw continues development
-        with subtests.test(msg="basic"):
-            assert inv.suggest("evolve")[0] == rst
+        check.equal(inv.suggest("evolve")[0], rst)
 
-        with subtests.test(msg="index"):
-            assert inv.suggest("evolve", with_index=True)[0] == (rst, idx)
+        check.equal(inv.suggest("evolve", with_index=True)[0], (rst, idx))
 
-        with subtests.test(msg="score"):
-            rec = inv.suggest("evolve", with_score=True)
-            assert rec[0][0] == rst
-            assert isinstance(rec[0][1], Number)
+        rec = inv.suggest("evolve", with_score=True)
+        check.equal(rec[0][0], rst)
+        check.is_instance(rec[0][1], Number)
 
-        with subtests.test(msg="index_and_score"):
-            rec = inv.suggest("evolve", with_index=True, with_score=True)
-            assert rec[0][0] == rst
-            assert isinstance(rec[0][1], Number)
-            assert rec[0][2] == idx
+        rec = inv.suggest("evolve", with_index=True, with_score=True)
+        check.equal(rec[0][0], rst)
+        check.is_instance(rec[0][1], Number)
+        check.equal(rec[0][2], idx)
 
     @pytest.mark.testall
     def test_api_inventory_datafile_gen_and_reimport(
@@ -491,7 +478,6 @@ class TestInventory:
         misc_info,
         sphinx_load_test,
         pytestconfig,
-        subtests,
     ):
         """Confirm integrated data_file export/import behavior."""
         fname = testall_inv_path.name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,7 +190,7 @@ class TestConvertGood:
         run_cmdline_test,
         misc_info,
         pytestconfig,
-        subtests,
+        check,
     ):
         """Confirm conversion in a loop, reading/writing all formats."""
         res_src_path = res_path / testall_inv_path
@@ -224,8 +224,7 @@ class TestConvertGood:
                 HeaderFields.Count.value,
             ),
         ):
-            with subtests.test(msg="{}_{}".format(fmt, attrib)):
-                assert getattr(invs[fmt], attrib) == getattr(invs["orig"], attrib)
+            check.equal(getattr(invs[fmt], attrib), getattr(invs["orig"], attrib))
 
     @pytest.mark.timeout(CLI_TEST_TIMEOUT)
     def test_cli_overwrite_prompt_and_behavior(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -445,17 +445,17 @@ class TestFail:
 
     @pytest.mark.timeout(CLI_TEST_TIMEOUT)
     def test_clifail_convert_localfile_as_url(
-        self, scratch_path, misc_info, run_cmdline_test, subtests
+        self, scratch_path, misc_info, run_cmdline_test, check
     ):
         """Confirm error when using URL mode on local file."""
         in_path = scratch_path / (misc_info.FNames.INIT + misc_info.Extensions.CMP)
 
         (scratch_path / (misc_info.FNames.INIT + misc_info.Extensions.DEC)).unlink()
 
-        with subtests.test(msg="path-style"):
+        with check.check(msg="path-style"):
             run_cmdline_test(["convert", "plain", "-u", str(in_path)], expect=1)
 
-        with subtests.test(msg="url-style"):
+        with check.check(msg="url-style"):
             file_url = "file:///" + str(in_path.resolve())
             run_cmdline_test(["convert", "plain", "-u", file_url], expect=1)
 

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -36,12 +36,12 @@ def test_info_fixture(misc_info):
     assert True in misc_info.byte_lines
 
 
-def test_populate_scratch(misc_info, scratch_path, subtests):
+def test_populate_scratch(misc_info, scratch_path, check):
     """Ensure the scratch_path fixture populates the scratch dir correctly."""
     scr_base = misc_info.FNames.INIT
 
     for ext in [_.value for _ in misc_info.Extensions]:
-        with subtests.test(msg=ext):
+        with check.check(msg=ext):
             assert (scratch_path / "{}{}".format(scr_base, ext)).is_file(), ext
 
 

--- a/tests/test_flake8_ext.py
+++ b/tests/test_flake8_ext.py
@@ -50,7 +50,7 @@ def skip_if_no_flake8_ext(pytestconfig):
     sys.version_info < (3, 6),
     reason="Some flake8 extensions require Python 3.6 or later",
 )
-def test_flake8_version_output(subtests):
+def test_flake8_version_output(check):
     """Confirm that all desired plugins actually report as loaded."""
     p_pkgname = re.compile("^[0-9a-z_-]+", re.I)
     plugins = Path("requirements-flake8.txt").read_text().splitlines()[1:]
@@ -64,6 +64,6 @@ def test_flake8_version_output(subtests):
         ["flake8", "--version"], universal_newlines=True
     )  # noqa: S607,S603
 
-    for i, p in enumerate(plugins):
-        with subtests.test(msg=p, i=i):
+    for p in plugins:
+        with check.check(msg=p):
             assert p in flake8_ver_output.replace("_", "-")

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -56,7 +56,7 @@ p_shell = re.compile(
     sphinx_ver != sphinx_req,
     reason="Skip if Sphinx version mismatches current dev version.",
 )
-def test_readme_shell_cmds(ensure_doc_scratch, subtests):
+def test_readme_shell_cmds(ensure_doc_scratch, check):
     """Perform testing on README shell command examples."""
     with open("README.rst") as f:
         text = f.read()
@@ -77,5 +77,5 @@ def test_readme_shell_cmds(ensure_doc_scratch, subtests):
 
         msg = "\n\nExpected:\n" + out + "\n\nGot:\n" + result
 
-        with subtests.test(i=i):
+        with check.check(msg="match_{}".format(i)):
             assert chk.check_output(out, result, dt_flags), msg

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ markers =
   first: Inherited marker from `pytest-ordering`
   timeout: Inherited marker from `pytest-timeout`
 
-addopts = --strict --doctest-glob="README.rst" -rsxX -Werror
+addopts = --strict-markers --doctest-glob="README.rst" -rsxX -Werror
 
 norecursedirs = .* env* src *.egg dist build
 


### PR DESCRIPTION
Cosmetic fix, but it was bugging me.

Closes #144 and #125 (had to switch away from `pytest-subtests`, at least for now, due to major compatibility problems (probably) with recent `pytest`).