### PR TITLE
Refactor file interactions to Paths

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -268,8 +268,7 @@ def file_head(fn, *, head=None):
     if not p.is_file():
         return "Not a file."
 
-    with p.open() as f:
-        text = f.read()
+    text = p.read_text()
 
     # If head==None, then just returns a complete slice
     lines = text.splitlines()[:head]

--- a/src/sphobjinv/fileops.py
+++ b/src/sphobjinv/fileops.py
@@ -25,6 +25,9 @@ Sphinx |objects.inv| files.
 
 """
 
+import json
+from pathlib import Path
+
 
 def readbytes(path):
     """Read file contents and return as |bytes|.
@@ -42,8 +45,7 @@ def readbytes(path):
         |bytes| -- Contents of the indicated file.
 
     """
-    with open(str(path), "rb") as f:
-        return f.read()
+    return Path(path).read_bytes()
 
 
 def writebytes(path, contents):
@@ -62,8 +64,7 @@ def writebytes(path, contents):
         |bytes| -- Content to be written to file.
 
     """
-    with open(str(path), "wb") as f:
-        f.write(contents)
+    Path(path).write_bytes(contents)
 
 
 def readjson(path):
@@ -84,10 +85,7 @@ def readjson(path):
         |dict| -- Deserialized JSON.
 
     """
-    import json
-
-    with open(str(path), "r") as f:
-        return json.load(f)
+    return json.loads(Path(path).read_text())
 
 
 def writejson(path, d):
@@ -107,10 +105,7 @@ def writejson(path, d):
         |dict| -- Data structure to serialize.
 
     """
-    import json
-
-    with open(str(path), "w") as f:
-        json.dump(d, f)
+    Path(path).write_text(json.dumps(d))
 
 
 def urlwalk(url):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,9 +212,8 @@ class TestConvertGood:
             "orig": Inventory(str(res_src_path)),
             "plain": Inventory(str(plain_path)),
             "zlib": Inventory(str(zlib_path)),
+            "json": Inventory(json.loads(json_path.read_text())),
         }
-        with json_path.open() as f:
-            invs.update({"json": Inventory(json.load(f))})
 
         for fmt, attrib in product(
             ("plain", "zlib", "json"),
@@ -396,8 +395,7 @@ class TestFail:
         """Confirm exit code 1 with invalid file format."""
         monkeypatch.chdir(scratch_path)
         fname = "testfile"
-        with Path(fname).open("wb") as f:
-            f.write(b"this is not objects.inv\n")
+        Path(fname).write_bytes(b"this is not objects.inv\n")
 
         with stdio_mgr() as (in_, out_, err_):
             run_cmdline_test(["convert", "plain", fname], expect=1)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -58,8 +58,7 @@ p_shell = re.compile(
 )
 def test_readme_shell_cmds(ensure_doc_scratch, check):
     """Perform testing on README shell command examples."""
-    with open("README.rst") as f:
-        text = f.read()
+    text = Path("README.rst").read_text()
 
     chk = dt.OutputChecker()
 


### PR DESCRIPTION
Where feasible, now using `.read_text()` and related methods.

Couple of spots that had to use explicit file handles, though.

Closes #167