### PR TITLE
Fix typo in doc/source/levenshtein.rst

### DIFF
--- a/doc/source/levenshtein.rst
+++ b/doc/source/levenshtein.rst
@@ -27,7 +27,7 @@ in the vast majority of cases::
     $ pip install sphobjinv[speedup]
 
 If you need to work with a version of |soi| prior to v2.1,
-the ``speedup`` extra is not avaialble and direct installation
+the ``speedup`` extra is not available and direct installation
 is required::
 
     $ pip install sphobjinv==2.0.1 python-Levenshtein


### PR DESCRIPTION
It used to say `avaialble`, but that should be `available`.