### PR TITLE
Fix new flake8-pie lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project strives to adhere to
   * The CLI functionality was refactored from the single `sphobjinv.cmdline` module
     into a dedicated set of `sphobjinv.cli.*` submodules.
 
+  * Some internal `type(...) is ...` checks were replaced with `isinstance(...)`
+
 #### Testing
 
   * Added *significant* body of new tests to confirm inventory compatibility

--- a/src/sphobjinv/data.py
+++ b/src/sphobjinv/data.py
@@ -63,9 +63,9 @@ def _utf8_decode(b):
     Helper for type conversions among DataObjStr and DataObjBytes.
 
     """
-    if type(b) is bytes:
+    if isinstance(b, bytes):
         return b.decode(encoding="utf-8")
-    elif type(b) is str:
+    elif isinstance(b, str):
         return b
     else:
         raise TypeError("Argument must be 'bytes' or 'str'")
@@ -77,15 +77,15 @@ def _utf8_encode(s):
     Helper for type conversions among DataObjStr and DataObjBytes.
 
     """
-    if type(s) is str:
+    if isinstance(s, str):
         return s.encode(encoding="utf-8")
-    elif type(s) is bytes:
+    elif isinstance(s, bytes):
         return s
     else:
         raise TypeError("Argument must be 'bytes' or 'str'")
 
 
-class SuperDataObj(object, metaclass=ABCMeta):
+class SuperDataObj(metaclass=ABCMeta):
     """Abstract base superclass defining common methods &c. for data objects.
 
     Intended only to be subclassed
@@ -119,25 +119,21 @@ class SuperDataObj(object, metaclass=ABCMeta):
     @abstractmethod
     def name(self):
         r"""Object name, as recognized internally by Sphinx\ |dag|."""
-        pass
 
     @property
     @abstractmethod
     def domain(self):
         r"""Sphinx domain containing the object\ |dag|."""
-        pass
 
     @property
     @abstractmethod
     def role(self):
         r"""Sphinx role to be used when referencing the object\ |dag|."""
-        pass
 
     @property
     @abstractmethod
     def priority(self):
         r"""Object search priority\ |dag|."""
-        pass
 
     @property
     @abstractmethod
@@ -147,7 +143,6 @@ class SuperDataObj(object, metaclass=ABCMeta):
         Possibly abbreviated; see :ref:`here <syntax_shorthand>`.
 
         """
-        pass
 
     @property
     @abstractmethod
@@ -157,7 +152,6 @@ class SuperDataObj(object, metaclass=ABCMeta):
         Possibly abbreviated; see :ref:`here <syntax_shorthand>`.
 
         """
-        pass
 
     @property
     @abstractmethod
@@ -168,7 +162,6 @@ class SuperDataObj(object, metaclass=ABCMeta):
         for :doc:`version 2 </syntax>` |objects.inv| files.
 
         """
-        pass
 
     @property
     @abstractmethod
@@ -179,24 +172,20 @@ class SuperDataObj(object, metaclass=ABCMeta):
         for :doc:`version 2 </syntax>` |objects.inv| files.
 
         """
-        pass
 
     @property
     @abstractmethod
     def as_str(self, s):
         """:class:`DataObjStr` version of instance."""
-        pass
 
     @property
     @abstractmethod
     def as_bytes(self, s):
         """:class:`DataObjBytes` version of instance."""
-        pass
 
     @abstractmethod
     def _data_line_postprocess(self, s):
         """Post-process the data_line chars output."""
-        pass
 
     @property
     def uri_contracted(self):

--- a/src/sphobjinv/inventory.py
+++ b/src/sphobjinv/inventory.py
@@ -46,7 +46,7 @@ from sphobjinv.zlib import decompress
 
 
 @attr.s(slots=True, eq=True, order=False)
-class Inventory(object):
+class Inventory:
     r"""Entire contents of an |objects.inv| inventory.
 
     All information is stored internally as |str|,

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -231,7 +231,7 @@ class TestDataObj:
             [soi.DataObjBytes, soi.pb_data, "byte_lines"],
             [soi.DataObjStr, soi.p_data, "str_lines"],
         ),
-        ids=(lambda i: i if type(i) == str else ""),
+        ids=(lambda i: i if isinstance(i, str) else ""),
     )
     @pytest.mark.parametrize("dataline_arg", (True, False))
     @pytest.mark.parametrize("init_expanded", (True, False))
@@ -332,7 +332,7 @@ class TestInventory:
             (soi.SourceTypes.FnamePlaintext, "fname_plain"),
             (soi.SourceTypes.FnameZlib, "fname_zlib"),
         ],
-        ids=(lambda v: v if type(v) == str else ""),
+        ids=(lambda v: v if isinstance(v, str) else ""),
     )
     @pytest.mark.parametrize("path_fxn", PATH_FXNS, ids=PATH_FXN_IDS)
     def test_api_inventory_bytes_fname_instantiation(


### PR DESCRIPTION

**Is the PR a fix or a feature?**
Lint fix

**Describe the changes in the PR**
- Removes some unnecessary `pass` statements and explicit inheritance from `object`
- Some internal `type(...) is ...` checks were replaced with `isinstance(...)`

**Does this PR close any issues?**
No.

**Does the PR change/update the following, if relevant?**
<!--
  All changes to code, even internal-only changes, should have
  a CHANGELOG entry. Documentation changes are usually only required
  if public-facing code or CLI behavior changes. Test coverage
  should be maintained at 100%, and all lints should be obeyed.

  Please specifically note if you want to use "# noqa",
  "# pragma: no cover", or similar flags/settings to disable
  any coverage/linting.
-->

- ~Documentation~
- ~Tests~
- [x] CHANGELOG

