### PR TITLE
Fix(Ignore) UnicodeDecodeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project strives to adhere to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+  * UnicodeDecodeErrors are ignored when converting inventories to ASCII.
 
 ### [2.2.1] - 2022-02-05
 

--- a/src/sphobjinv/_vendored/fuzzywuzzy/utils.py
+++ b/src/sphobjinv/_vendored/fuzzywuzzy/utils.py
@@ -9,7 +9,7 @@ trans_table=bytes.maketrans(table_from.encode(), table_to.encode())  # B Skinn 2
 
 
 def asciionly(s):
-    return s.encode().translate(None, bad_chars).decode()  # B Skinn 2021-12-11
+    return s.encode().translate(None, bad_chars).decode(errors='replace')  # B Skinn 2021-12-11
 
 # remove non-ASCII characters from strings
 def asciidammit(s):
@@ -32,8 +32,4 @@ def validate_string(s):
 def full_process(s):
     s = asciidammit(s)
     # B Skinn 2021-12-11
-    return s.encode().translate(trans_table, bad_chars).decode().strip()
-
-
-
-
+    return s.encode().translate(trans_table, bad_chars).decode(errors='replace').strip()

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -474,14 +474,6 @@ class TestInventory:
         """Confirm that a suggest operation works on all smoke-test inventories."""
         inv = soi.Inventory(testall_inv_path)
 
-        if "fonttools" in inv.project.lower():
-            try:
-                inv.suggest("class")
-            except UnicodeDecodeError:
-                pytest.xfail("Known unhandled bad character in decode operation")
-            else:  # pragma: no cover
-                pytest.fail("'fonttools' was expected to fail, but didn't")
-
         inv.suggest("class")
 
     @pytest.mark.testall


### PR DESCRIPTION
<!-- THANKS FOR YOUR CONTRIBUTION!! -->

**Is the PR a fix or a feature?**
<!-- Please indicate the type of change the PR will make. -->

Reduces (removes?) the risk of getting UnicodeDecodeErrors. Unknown consequences for the actual search functionality...

**Describe the changes in the PR**
<!--
  Whatever level of detail is necessary to describe the changes well.
  A simple reference to associated issue(s) may suffice here
  (e.g., "Closes #113"), if the description/discussion there is
  complete enough.
-->

This may not be the correct way to actually solve it, but it does remove the error and makes suggest work on the objects.inv in question.

Not sure if I should have added a test (the only way I could think of was a smoke test for that particular URL, which I thought didn't really make sense, as it will require a download and the issue may go away from there).

I hope the CHANGELOG entry is close to acceptable.

**Does this PR close any issues?**
<!--
  If not indicated in the above PR description, indicate here
  which issue(s) are closed by the PR, if any; e.g.:

  Closes #112 and closes #117.

  Please use a separate 'closes' with each issue number,
  to be sure that Github links the PR correctly to each closed issue.
-->
Closes #225 

**Does the PR change/update the following, if relevant?**
<!--
  All changes to code, even internal-only changes, should have
  a CHANGELOG entry. Documentation changes are usually only required
  if public-facing code or CLI behavior changes. Test coverage
  should be maintained at 100%, and all lints should be obeyed.

  Please specifically note if you want to use "# noqa",
  "# pragma: no cover", or similar flags/settings to disable
  any coverage/linting.
-->

- Documentation *(Ed: Not needed)*
- [x] Tests
- [x] CHANGELOG

