### PR TITLE
Add test case info for `objects_fonttools.inv` and add --testall suggestion functionality test

### DIFF
--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -448,7 +448,7 @@ class TestInventory:
         assert inv2.count == 55
 
     def test_api_inventory_namesuggest(self, res_cmp, check):
-        """Confirm object name suggestion is nominally working."""
+        """Confirm object name suggestion is nominally working on a specific object."""
         rst = ":py:function:`attr.evolve`"
         idx = 6
 
@@ -468,6 +468,18 @@ class TestInventory:
         check.equal(rec[0][0], rst)
         check.is_instance(rec[0][1], Number)
         check.equal(rec[0][2], idx)
+
+
+    @pytest.mark.testall
+    def test_api_inventory_suggest_operation(self, testall_inv_path):
+        """Confirm that a suggest operation works on all smoke-test inventories."""
+        inv = soi.Inventory(testall_inv_path)
+
+        if "fonttools" in inv.project.lower():
+            pytest.xfail("Known bad character in decode operation")
+
+        inv.suggest("class")
+
 
     @pytest.mark.testall
     def test_api_inventory_datafile_gen_and_reimport(

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -475,7 +475,12 @@ class TestInventory:
         inv = soi.Inventory(testall_inv_path)
 
         if "fonttools" in inv.project.lower():
-            pytest.xfail("Known bad character in decode operation")
+            try:
+                inv.suggest("class")
+            except UnicodeDecodeError:
+                pytest.xfail("Known unhandled bad character in decode operation")
+            else:
+                pytest.fail("'fonttools' was expected to fail, but didn't")
 
         inv.suggest("class")
 

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -469,7 +469,6 @@ class TestInventory:
         check.is_instance(rec[0][1], Number)
         check.equal(rec[0][2], idx)
 
-
     @pytest.mark.testall
     def test_api_inventory_suggest_operation(self, testall_inv_path):
         """Confirm that a suggest operation works on all smoke-test inventories."""
@@ -479,7 +478,6 @@ class TestInventory:
             pytest.xfail("Known bad character in decode operation")
 
         inv.suggest("class")
-
 
     @pytest.mark.testall
     def test_api_inventory_datafile_gen_and_reimport(

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -479,7 +479,7 @@ class TestInventory:
                 inv.suggest("class")
             except UnicodeDecodeError:
                 pytest.xfail("Known unhandled bad character in decode operation")
-            else:
+            else:  # pragma: no cov
                 pytest.fail("'fonttools' was expected to fail, but didn't")
 
         inv.suggest("class")

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -479,7 +479,7 @@ class TestInventory:
                 inv.suggest("class")
             except UnicodeDecodeError:
                 pytest.xfail("Known unhandled bad character in decode operation")
-            else:  # pragma: no cov
+            else:  # pragma: no cover
                 pytest.fail("'fonttools' was expected to fail, but didn't")
 
         inv.suggest("class")

--- a/tests/test_api_good.py
+++ b/tests/test_api_good.py
@@ -555,6 +555,12 @@ class TestInventory:
             else:
                 assert inv.count == sphinx_ifile_data_count(original_ifile_data), fname
 
+        elif "fonttools" in fname:  # pragma: no cover
+            # One object appears to have a misbehaving character that Sphinx
+            # rejects on an attempted import
+            # TODO: Figure out which Sphinx versions this is broken on and refine test
+            assert inv.count == 1 + sphinx_ifile_data_count(original_ifile_data), fname
+
         else:
             assert inv.count == sphinx_ifile_data_count(original_ifile_data), fname
 


### PR DESCRIPTION
Setting the groundwork for the test suite and CI to work cleanly with #226.

The `pytest.xfail` for the `fonttools` case in the new '--testall suggest' test should trigger with the fix in #226.