### PR TITLE
Setup: Modernize to license_files and improve __version__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,15 @@ and this project strives to adhere to
 
 #### Internal
 
-  * Bump pre-commit black hook to v22.3.0
+  * Bump pre-commit black hook to v22.3.0.
 
-  * Remove PyPy and Python 3.6 from Azure Pipelines test matrix
+  * Remove PyPy and Python 3.6 from Azure Pipelines test matrix.
+
+  * Revise `__version__` retrieval in `setup.py` to use an intermediate
+    dictionary with `exec()`.
+
+  * Update `setup.cfg` to use `license_files`, instead of the deprecated
+    `license_file`.
 
 
 ### [2.2.2] - 2022-03-22

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,8 @@ project_urls =
     Thank=https://twitter.com/btskinn
     Donate=https://github.com/sponsors/bskinn
 license = MIT License
-license_file = LICENSE.txt
+license_files =
+    LICENSE.txt
 platforms = any
 author = Brian Skinn
 author_email = bskinn@alum.mit.edu
@@ -54,4 +55,3 @@ where = src
 [options.entry_points]
 console_scripts =
     sphobjinv=sphobjinv.cli.core:main
-    

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,9 @@ from setuptools import setup
 
 NAME = "sphobjinv"
 
-exec(Path("src", "sphobjinv", "version.py").read_text(encoding="utf-8"))
-
+exec_ns = {}
+exec(Path("src", "sphobjinv", "version.py").read_text(encoding="utf-8"), exec_ns)
+__version__ = exec_ns["__version__"]
 
 version_override = "2.2"
 


### PR DESCRIPTION
The old `license_file` setup.cfg field is deprecated, with the
list-based license_files now preferred. Fixed.

Improved the retrieval of `__version__` from within the package
by using an intermediary namespace dict with `exec()`, and recovering
the retrieved value from that.

<!-- THANKS FOR YOUR CONTRIBUTION!! -->

**Is the PR a fix or a feature?**
<!-- Please indicate the type of change the PR will make. -->

**Describe the changes in the PR**
<!--
  Whatever level of detail is necessary to describe the changes well.
  A simple reference to associated issue(s) may suffice here
  (e.g., "Closes #113"), if the description/discussion there is
  complete enough.
-->

**Does this PR close any issues?**
<!--
  If not indicated in the above PR description, indicate here
  which issue(s) are closed by the PR, if any; e.g.:

  Closes #112 and closes #117.

  Please use a separate 'closes' with each issue number,
  to be sure that Github links the PR correctly to each closed issue.
-->

**Does the PR change/update the following, if relevant?**
<!--
  All changes to code, even internal-only changes, should have
  a CHANGELOG entry. Documentation changes are usually only required
  if public-facing code or CLI behavior changes. Test coverage
  should be maintained at 100%, and all lints should be obeyed.

  Please specifically note if you want to use "# noqa",
  "# pragma: no cover", or similar flags/settings to disable
  any coverage/linting.
-->

- x Documentation
- x Tests
- [x] CHANGELOG

