### PR TITLE
Modify CLI suggest output and mechanics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,17 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v3.2.0'
+    rev: 'v4.3.0'
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: '22.3.0'
+    rev: '22.10.0'
     hooks:
     -   id: black
 -   repo: https://github.com/tox-dev/pyproject-fmt
-    rev: '0.3.2'
+    rev: '0.3.5'
     hooks:
     -   id: pyproject-fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project strives to adhere to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+### (unreleased)
+
+#### Changed
+
+  * The printout of the inferred `intersphinx_mapping` item for inventories
+    retrieved by URL (`--url`) in the 'suggest' CLI mode is now relocated to
+    fall immediately below the inventory-search output. ([#262](https://github.com/bskinn/sphobjinv/issues/262))
+
+  * The 'suggest' CLI mode output now includes dividers for improved
+    readability.
+
+#### Internal
+
+  * The `sys.exit()` in the case of no objects falling above the 'suggest' search threshold was refactored into the main `do_suggest()` body, to minimize the surprise of an `exit()` call coming in a subfunction. ([#263](https://github.com/bskinn/sphobjinv/issues/263))
+
+
 ### [2.3] - 2022-11-08
 
 #### Added
@@ -66,7 +82,8 @@ and this project strives to adhere to
     `objects_sphinx.inv`, and the previous v1.6.6 was renamed to
     `objects_sphinx_1_6_6.inv`.
 
-  * The 'valid objects' test cases were updated to reflect the possibility for a colon within `{role}`:
+  * The 'valid objects' test cases were updated to reflect the possibility for a
+    colon within `{role}`:
 
     * The colon-within-`{role}` test case was moved from 'invalid' to 'valid'.
 

--- a/README.rst
+++ b/README.rst
@@ -57,14 +57,21 @@ For internal cross-references, locate ``objects.inv`` within ``build/html``::
 
     $ sphobjinv suggest doc/build/html/objects.inv as_rst -st 58
 
+    ------------------------------------------------
+
+    Cannot infer intersphinx_mapping from a local objects.inv.
+
+    ------------------------------------------------
+
     Project: sphobjinv
     Version: 2.3
 
     219 objects in inventory.
 
+    ------------------------------------------------
+
     11 results found at/above current threshold of 58.
 
-    Cannot infer intersphinx_mapping from a local objects.inv.
 
       Name                                                Score
     ---------------------------------------------------  -------
@@ -103,16 +110,22 @@ cross-reference the ``linspace`` function from numpy (see
     Attempting "https://numpy.org/doc/1.23/objects.inv" ...
       ... inventory found.
 
+    ------------------------------------------------
+
+    The intersphinx_mapping for this docset is LIKELY:
+
+      (https://numpy.org/doc/1.23/, None)
+
+    ------------------------------------------------
+
     Project: NumPy
     Version: 1.23
 
     8074 objects in inventory.
 
+    ------------------------------------------------
+
     8 results found at/above current threshold of 75.
-
-    The intersphinx_mapping for this docset is LIKELY:
-
-      (https://numpy.org/doc/1.23/, None)
 
 
       Name                                                           Score

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ For internal cross-references, locate ``objects.inv`` within ``build/html``::
     Project: sphobjinv
     Version: 2.3
 
-    219 objects in inventory.
+    220 objects in inventory.
 
     ------------------------------------------------
 
@@ -170,7 +170,7 @@ inventory creation/modification::
     >>> import sphobjinv as soi
     >>> inv = soi.Inventory('doc/build/html/objects.inv')
     >>> print(inv)
-    <Inventory (fname_zlib): sphobjinv v2.3, 219 objects>
+    <Inventory (fname_zlib): sphobjinv v2.3, 220 objects>
     >>> inv.project
     'sphobjinv'
     >>> inv.version

--- a/src/sphobjinv/cli/suggest.py
+++ b/src/sphobjinv/cli/suggest.py
@@ -78,20 +78,33 @@ def do_suggest(inv, params):
         with_score=with_score,
     )
 
+    print_divider(params)
+    print_stderr_inferred_mapping(params)
+    print_divider(params)
+
     print_stderr(f"Project: {inv.project}", params)
     print_stderr(f"Version: {inv.version}\n", params)
 
     print_stderr(f"{inv.count} objects in inventory.\n", params)
+    print_divider(params)
 
     print_stderr_result_count(params, results)
 
-    print_stderr_inferred_mapping(params)
+    if not results:
+        print_stderr("\nExiting...\n", params)
+        sys.exit(0)
 
     # The query here for printing the full list only occurs in some
     # circumstances; see the function docstring.
     confirm_print_if_long_list(params, results)
 
     print_results_table(with_index, with_score, results, params)
+
+
+def print_divider(params):
+    """Print a visual divider to break up sections of the CLI output."""
+    length = shutil.get_terminal_size().columns * 3 // 5
+    print_stderr("-" * length + "\n", params)
 
 
 def print_stderr_result_count(params, results):
@@ -104,7 +117,6 @@ def print_stderr_result_count(params, results):
             ),
             params,
         )
-        sys.exit(0)
     else:
         print_stderr(
             (


### PR DESCRIPTION
- Re-order the up-front output for CLI suggest
- Add dividers to CLI suggest up-front output for easier readability
- Relocate internal `sys.exit()` for reduced surprise