### PR TITLE
Mention priority 0 and 2

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -55,7 +55,7 @@ and package managers, including:
 
   * Alpine Linux: ``py3-sphobjinv`` (`info <https://pkgs.alpinelinux.org/packages?name=py3-sphobjinv>`__)
 
-  * Arch Linux: ``python-sphobjinv`` (`info <https://archlinux.org/packages/community/any/python-sphobjinv/>`__)
+  * Arch Linux: ``python-sphobjinv`` (`info <https://archlinux.org/packages/extra/any/python-sphobjinv/>`__)
 
   * Fedora: ``python-sphobjinv`` (`info <https://src.fedoraproject.org/rpms/python-sphobjinv>`__)
 

--- a/doc/source/syntax.rst
+++ b/doc/source/syntax.rst
@@ -133,7 +133,8 @@ the string ``zlib`` somewhere within it, but for consistency it should be exactl
 ``{priority}``
     Flag for `placement in search results
     <https://github.com/sphinx-doc/sphinx/blob/2f60b44999d7e610d932529784f082fc1c6af989/sphinx/domains/__init__.py#L370-L381>`__. Most will be ``1`` (standard priority) or
-    ``-1`` (omit from results) for documentation built by Sphinx.
+    ``-1`` (omit from results) for documentation built by Sphinx;
+    values of ``0`` (higher priority) or ``2`` (lower priority) may also occur.
 
     To note, as of Jan 2022 this value is **not** used by ``intersphinx``;
     it is only used internally within the search function of the static webpages


### PR DESCRIPTION
<!-- THANKS FOR YOUR CONTRIBUTION!! -->

**Is the PR a fix or a feature?**
Docs change.

**Describe the changes in the PR**
I simply add a mention of what Sphinx expects for priorities other than 1 and -1.
Just reading the current docs led to me think 0 would be low priority, and then 2, 3, 4, etc. higher priorities.
I'm not sure if priorities higher than 2 make sense to Sphinx :confused: 

**Does this PR close any issues?**
No.

**Does the PR change/update the following, if relevant?**
- [x] Documentation
- [ ] Tests
- [ ] CHANGELOG

