### PR TITLE
Fixup: add missing call operator in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project follows an extension of
 fourth number represents an administrative maintenance release with no code
 changes.
 
+### Unreleased
+
+#### Fixed
+
+  * The `super` keyword used in a statement in the HTML footer
+    template was missing parentheses to perform a method call; this
+    caused the template rendering to emit a Python string describing
+    the parent template object, instead of rendering the parent
+    template as intended.
+    ([#298](https://github.com/bskinn/sphobjinv/issues/298))
+
 ### [2.3.1.1] - 2024-05-21
 
 #### Tests

--- a/doc/source/_templates/footer.html
+++ b/doc/source/_templates/footer.html
@@ -2,7 +2,7 @@
 
 {%-block extrafooter %}
 
-{{ super }}
+{{ super() }}
 
 <br /><br />
 


### PR DESCRIPTION
**Is the PR a fix or a feature?**
Fix

**Describe the changes in the PR**
The `super` keyword used in a statement in the HTML footer template was missing parentheses to perform a method call; this caused the template rendering to emit a Python string describing the parent template object, instead of rendering the parent template as intended.

**Does this PR close any issues?**
Closes #298.

**Does the PR change/update the following, if relevant?**
- [x] Documentation
- [ ] Tests
- [x] CHANGELOG