### PR TITLE
Trim project dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project follows an extension of
 fourth number represents an administrative maintenance release with no code
 changes.
 
+### *Unreleased*
+
+#### Internal
+
+  * Bump dev Sphinx version to 7.4.7 ([#305]).
+    * We stay under 8.0 because Sphinx v8 drops Python 3.9.
+
+  * Clean up dependencies ([#305]).
+    * Remove `pytest-ordering`, as it is no longer used in the test suite and is
+      falling out of maintenance enough to start causing some things to fail.
+    * Remove `sphinx-removed-in`, as `.. versionremoved::` is now a Sphinx
+      built-in.
+    * Remove `interrogate`, `pre-commit`, `rope`, `wget` from `requirements-dev.txt`.
+      * No longer used for most; for `rope`, now no plans to use it.
+
+
 ### [2.3.1.2] - 2024-12-22
 
 #### Internal
@@ -612,3 +628,4 @@ changes.
 
 [#287]: https://github.com/bskinn/sphobjinv/issues/287
 [#289]: https://github.com/bskinn/sphobjinv/pull/289
+[#305]: https://github.com/bskinn/sphobjinv/pull/305

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinxcontrib.programoutput",
     "sphinx_issues",
-    "sphinx_removed_in",
 ]
 
 # napoleon configuration

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,7 +11,6 @@ pytest-cov
 pytest-timeout
 sphinx==7.4.7
 sphinx-issues
-# sphinx-removed-in
 sphinx-rtd-theme>=0.5.1
 sphinxcontrib-programoutput
 stdio-mgr>=1.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,9 +9,9 @@ pytest>=4.4.0
 pytest-check>=1.1.2
 pytest-cov
 pytest-timeout
-sphinx==7.1.2
+sphinx==7.4.7
 sphinx-issues
-sphinx-removed-in
+# sphinx-removed-in
 sphinx-rtd-theme>=0.5.1
 sphinxcontrib-programoutput
 stdio-mgr>=1.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,7 +8,6 @@ md-toc
 pytest>=4.4.0
 pytest-check>=1.1.2
 pytest-cov
-pytest-ordering
 pytest-timeout
 sphinx==7.1.2
 sphinx-issues

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,11 +7,9 @@ interrogate
 jsonschema
 md-toc
 pep517
-pre-commit
 pytest>=4.4.0
 pytest-check>=1.1.2
 pytest-cov
-pytest-ordering
 pytest-timeout
 restview
 rope

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,6 @@ restview
 sphinx==7.4.7  # Staying <8 since 8.0 drops Python 3.9
 sphinx-autobuild
 sphinx-issues
-# sphinx-removed-in
 sphinx-rtd-theme>=0.5.1
 sphinxcontrib-programoutput
 stdio-mgr>=1.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ build
 certifi
 coverage
 dictdiffer
-interrogate
 jsonschema
 md-toc
 pep517
@@ -12,7 +11,7 @@ pytest-check>=1.1.2
 pytest-cov
 pytest-timeout
 restview
-rope
+
 sphinx==7.1.2
 sphinx-autobuild
 sphinx-issues
@@ -22,6 +21,5 @@ sphinxcontrib-programoutput
 stdio-mgr>=1.0.1
 tox
 twine
-wget
 -r requirements-flake8.txt
 -e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,11 +11,10 @@ pytest-check>=1.1.2
 pytest-cov
 pytest-timeout
 restview
-
-sphinx==7.1.2
+sphinx==7.4.7  # Staying <8 since 8.0 drops Python 3.9
 sphinx-autobuild
 sphinx-issues
-sphinx-removed-in
+# sphinx-removed-in
 sphinx-rtd-theme>=0.5.1
 sphinxcontrib-programoutput
 stdio-mgr>=1.0.1

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,6 +1,5 @@
 attrs>=19.2
 sphinx==7.4.7
 sphinx-issues
-# sphinx-removed-in
 sphinx-rtd-theme>=0.5.1
 sphinxcontrib-programoutput

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,6 +1,6 @@
 attrs>=19.2
-sphinx==7.1.2
+sphinx==7.4.7
 sphinx-issues
-sphinx-removed-in
+# sphinx-removed-in
 sphinx-rtd-theme>=0.5.1
 sphinxcontrib-programoutput


### PR DESCRIPTION
- `sphinx-ordering` is no longer used in the test suite, and is starting to fall out of compatibility in some environments
- `sphinx-removed-in` is obsolete since Sphinx 7.3