### PR TITLE
Skip more characters in test_name_lead_chars for Sphinx 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ changes.
       problems.
   * Skip more characters in `test_name_lead_chars` for Sphinx 8.2+, that started
     using `splitlines()` instead of `split('\n')` ([#315]).
-  * Run the tests with boundary Sphinx versions: 8.1.3 and 8.2.0.
+    * Add the boundary Sphinx versions 8.1.3 and 8.2.0 to the tox env list.
 
 #### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ changes.
   * Add `pytest-retry` to dev requirements and some `flaky` marks ([#306]).
     * Hopefully will iron out some of the test failures due to transient network
       problems.
+  * Skip more characters in `test_name_lead_chars` for Sphinx 8.2+, that started
+    using `splitlines()` instead of `split('\n')` ([#315]).
+  * Run the tests with boundary Sphinx versions: 8.1.3 and 8.2.0.
 
 #### Internal
 
@@ -670,4 +673,5 @@ changes.
 [#289]: https://github.com/bskinn/sphobjinv/pull/289
 [#305]: https://github.com/bskinn/sphobjinv/pull/305
 [#306]: https://github.com/bskinn/sphobjinv/pull/306
+[#315]: https://github.com/bskinn/sphobjinv/pull/315
 [#316]: https://github.com/bskinn/sphobjinv/pull/316

--- a/tests/test_valid_objects.py
+++ b/tests/test_valid_objects.py
@@ -34,6 +34,7 @@ import zlib
 from io import BytesIO
 
 import pytest
+import sphinx
 from sphinx.util.inventory import InventoryFile as IFile
 
 import sphobjinv as soi
@@ -166,9 +167,14 @@ def test_name_lead_chars(misc_info, sphinx_ifile_data_count, leadint):
     """Screen for valid/invalid first characters."""
     name = int_to_latin_1(leadint) + " foo"
 
-    # Expect only two fail cases, newline and '#'
+    # For Sphinx < 8.2 expect only two fail cases, newline and '#'
     if leadint in (10, 35):
         pytest.xfail("Known invalid name lead char")
+
+    # Sphinx >= 8.2 uses splitlines(), which strips more line boundary characters.
+    # See https://github.com/bskinn/sphobjinv/issues/314
+    if sphinx.version_info >= (8, 2) and leadint in (11, 12, 13, 28, 29, 30, 133):
+        pytest.xfail("Known invalid name lead char for Sphinx >= 8.2")
 
     test_dataobjstr_valid_objects(
         misc_info,

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ envlist=
     # Spot matrix of early Python, Sphinx, attrs versions
     py3{9,10}-sphx_{1,2}_x-attrs_{19,20}_2-jsch_latest
     # Test the specific Sphinx threshold cases where behavior changed
-    py312-sphx_{2_3_1,2_4_0,3_2_1,3_3_0,3_4_0}-attrs_latest-jsch_latest
+    py312-sphx_{2_3_1,2_4_0,3_2_1,3_3_0,3_4_0,8_1_3,8_2_0}-attrs_latest-jsch_latest
     # Simple 'does the sdist install' check
     sdist_install
     # Lints
@@ -48,6 +48,8 @@ deps=
     sphx_3_2_1:   sphinx==3.2.1
     sphx_3_3_0:   sphinx==3.3.0
     sphx_3_4_0:   sphinx==3.4.0
+    sphx_8_1_3:   sphinx==8.1.3
+    sphx_8_2_0:   sphinx==8.2.0
     sphx_latest:  sphinx
     sphx_dev:     git+https://github.com/sphinx-doc/sphinx
 

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ deps=
     pytest>=4.4.0
     pytest-check>=1.1.2
     pytest-ordering
+    pytest-retry
     pytest-timeout
     stdio-mgr>=1.0.1
     sphinx-issues


### PR DESCRIPTION
This PR will (hopefully) make the tests pass with Sphinx 8.2.

See #314 for the related discussion.